### PR TITLE
Typos and next up links

### DIFF
--- a/basics.md
+++ b/basics.md
@@ -31,7 +31,7 @@ If the ready counter is 0, then something went wrong :(.
 
 Consuming messages in different ways. The methods illustrated below are relevant only for debugging purposes. 
 
-### Instrcutions
+### Instructions
 
 Let's start by inspecting the message we sent through the management console:
 
@@ -62,3 +62,5 @@ $ rabbitmqadmin list queues name messages_ready
 That last two parameters are the names of the columns that you want the CLI to print out when listing the queues. In this case we just wanted to see the queue name and number of messages in ready state.
 
 Feel free to play with the `list queues` command for a while. This might come in handy one day!
+
+Next up: [Implementing PubSub with RabbitMQ](pubsub.md)

--- a/pubsub.md
+++ b/pubsub.md
@@ -8,7 +8,7 @@ Wait...what? No one told me that exchanges can have types! Well.. they can. In f
 
 ## Goal
 
-Implemet a Pub/Sub using a `fanout` exchange
+Implement a Pub/Sub using a `fanout` exchange
 
 ## Instructions
 
@@ -74,3 +74,5 @@ What happened is that we **published** a message to the `pubsub` exchange and it
 ## Recap
 
 The PubSub design pattern can be implemented in RabbitMQ by binding multiple queues to a `fanout` exchange. Every message published to that exchange will be sent to all queues bound to it.
+
+Next up: [Basic Routing](basicrouting.md)

--- a/setup.md
+++ b/setup.md
@@ -19,3 +19,5 @@ Password: **guest**
 Open http://localhost:15672/cli/rabbitmqadmin  
 Save the output to `/usr/local/bin/rabbitmqadmin`  
 Check that it works: `rabbitmqadmin list exchanges` 
+
+Next up: [The Basics: Queues and Exchanges](basics.md)


### PR DESCRIPTION
Small typos and links between steps (MOAR comfortable when browsing in Github / Vim)